### PR TITLE
Fixes, mostly to where eclipse is extracted

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 pkg/
+/.project

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 pkg/
-/.project

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -52,12 +52,14 @@ class eclipse::install::download (
     url      => $url,
     target   => $eclipse::params::target_dir,
     timeout  => 0,
+    root_dir => 'eclipse',
+    strip_components => 1
   }
 
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => '755',
+    mode    => '644',
     require => Archive[$filename]
   }
 

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -38,7 +38,7 @@ class eclipse::install::download (
       subscribe   => Archive[$filename]
     }
     exec { 'eclipse write permissions':
-      command     => "bin/chmod -R g+w '${eclipse::params::target_dir}/eclipse'",
+      command     => "/bin/chmod -R g+w '${eclipse::params::target_dir}/eclipse'",
       refreshonly => true,
       subscribe   => Archive[$filename]
     }

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -5,9 +5,7 @@
 # Sample Usage:
 #
 #  include eclipse::install::download
-#--
-# TODO: Enable desktop shortcut for given users.
-#++
+#
 class eclipse::install::download (
   $package         = 'standard',
   $release_name    = 'kepler',
@@ -59,7 +57,7 @@ class eclipse::install::download (
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => '644',
+    mode    => 644,
     require => Archive[$filename]
   }
 

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -28,17 +28,17 @@ class eclipse::install::download (
 
   if $owner_group and $ensure == 'present' {
     exec { 'eclipse ownership':
-      command     => "chgrp -R '${owner_group}' '${eclipse::params::target_dir}/eclipse'",
+      command     => "/bin/chgrp -R '${owner_group}' '${eclipse::params::target_dir}/eclipse'",
       refreshonly => true,
       subscribe   => Archive[$filename]
     }
     exec { 'eclipse group permissions':
-      command     => "find '${eclipse::params::target_dir}/eclipse' -type d -exec chmod g+s {} \\;",
+      command     => "/bin/find '${eclipse::params::target_dir}/eclipse' -type d -exec chmod g+s {} \\;",
       refreshonly => true,
       subscribe   => Archive[$filename]
     }
     exec { 'eclipse write permissions':
-      command     => "chmod -R g+w '${eclipse::params::target_dir}/eclipse'",
+      command     => "bin/chmod -R g+w '${eclipse::params::target_dir}/eclipse'",
       refreshonly => true,
       subscribe   => Archive[$filename]
     }
@@ -55,7 +55,7 @@ class eclipse::install::download (
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => 644,
+    mode    => '644',
     require => Archive[$filename]
   }
 

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -16,6 +16,7 @@ class eclipse::install::download (
 ) {
 
   include eclipse::params
+  include archive::prerequisites
 
   $archsuffix = $::architecture ? {
     /i.86/           => '',

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -5,7 +5,9 @@
 # Sample Usage:
 #
 #  include eclipse::install::download
-#
+#--
+# TODO: Enable desktop shortcut for given users.
+#++
 class eclipse::install::download (
   $package         = 'standard',
   $release_name    = 'kepler',
@@ -49,14 +51,13 @@ class eclipse::install::download (
     ensure   => $ensure,
     url      => $url,
     target   => $eclipse::params::target_dir,
-    root_dir => 'eclipse',
     timeout  => 0,
   }
 
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => '644',
+    mode    => '755',
     require => Archive[$filename]
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,23 @@
+{
+	"name": "mjanser-eclipse",
+	"version": "0.2.0",
+	"author": "Martin Janser",
+	"summary": "Install Eclipse",
+	"license": "MIT",
+	"description": "Install Eclipse with plugins",
+	"source": "git://github.com/mjanser/puppet-eclipse.git",
+	"project_page": "https://github.com/mjanser/puppet-eclipse.git",
+	"requirements": [{
+			"name": "pe",
+			"version_requirement": ">= 3.0.0 < 2015.4.0"
+		},{
+			"name": "puppet",
+			"version_requirement": ">= 3.0.0 < 5.0.0"
+		}
+	],
+	"dependencies": [{
+			"name": "gini/archive",
+			"version_requirement": ">= 0.2.0"
+		}
+	]
+}


### PR DESCRIPTION
It would be good if you could merge in these changes which mostly just bring the module up to date and make sure eclipse ends up extracted in a way that the executable is at /opt/eclipse/eclipse.