### PR TITLE
Fix download.pp file mode reference for Puppet 4

### DIFF
--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -57,7 +57,7 @@ class eclipse::install::download (
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => 644,
+    mode    => '644',
     require => Archive[$filename]
   }
 


### PR DESCRIPTION
Issue discovered using this module with Puppet 4 as file mode attribute only supports string value now.

- Reported error: 'Error: Parameter mode failed on
File[/usr/share/applications/opt-eclipse.desktop]: The file mode
specification must be a string, not 'Fixnum' at
/tmp/vagrant-puppet/environments/lq_control_repo/modules/eclipse/manifests/install/download.pp:57'

- Deprecation Ref:
https://docs.puppet.com/puppet/3.7/reference/deprecated_resource.html#non-string-mode-values