### PR TITLE
Default Kepler to SR2 service release

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@
 class eclipse (
   $package         = 'standard',
   $release_name    = 'kepler',
-  $service_release = 'SR1',
+  $service_release = 'SR2',
   $method          = 'package',
   $owner_group     = undef,
   $ensure          = present

--- a/manifests/install/download.pp
+++ b/manifests/install/download.pp
@@ -57,7 +57,7 @@ class eclipse::install::download (
   file { '/usr/share/applications/opt-eclipse.desktop':
     ensure  => $ensure,
     content => template('eclipse/opt-eclipse.desktop.erb'),
-    mode    => 644,
+    mode    => '644',
     require => Archive[$filename]
   }
 


### PR DESCRIPTION
Change Kepler default from unavailable SR1
- Changed service_release to SR2 as SR1 no longer available for Kepler
- Also includes changes from pull request https://github.com/mjanser/puppet-eclipse/pull/6