### PR TITLE
switching dependancy from module gini-archive to puppet-archive

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,8 +16,8 @@
 		}
 	],
 	"dependencies": [{
-			"name": "gini/archive",
-			"version_requirement": ">= 0.2.0"
+			"name": "puppet/archive",
+			"version_requirement": ">= 1.1.3"
 		}
 	]
 }


### PR DESCRIPTION
install method "download" seems to be broken with module gini-archive,
so updated install method "download" works with  module puppet-archive.

tested in PE puppet v4.9